### PR TITLE
Re-authentication if token got invalidated

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ If an options object is not provided, you'd need to prvide user name/ api key wh
 * `authenticate(userName, apiKey, callback)` - user name and apiKey can be skipped if provided at class initialization.
 If `persistedTokenPath` has been provided to constructor, the auth token will be saved to a local file, and read from it the next time `suthenticate is called. This could sae network calls, and speed future operatiosn. Auth tokens are good for 24 hours. 
 * `getClientId()` - return the client id of the queue. Useful if you've generated a random client id.
+* `deleteToken()` - deletes the currently used token which makes it possible to re-authenticate even if the actual token isn't expired yet.
 
 ###Queue operations
 

--- a/lib/racq.js
+++ b/lib/racq.js
@@ -221,6 +221,13 @@ var RacQ = function(options) {
 		return _clientId;
 	};
 
+    /**
+     * Deletes the currently used token which makes it possible to re-authenticate even if the current token isn't expired yet
+     */
+    this.deleteToken = function() {
+        _token = null;
+    }
+
 	/**
 	 * Get current network statistics (for accounting purposes)
 	 * @return {Object} statistics object containing number of calls, bytes sent, and bytes recieved so far
@@ -717,14 +724,6 @@ var RacQ = function(options) {
 			}
 		});
 	};
-
-    /**
-     * Resets the token to allow fetching new token even if the current one isn't expired yet
-     *
-     */
-    this.deleteToken = function() {
-        _token = null;
-    }
 };
 
 module.exports = RacQ;

--- a/lib/racq.js
+++ b/lib/racq.js
@@ -1,7 +1,7 @@
 'use strict';
 /**
  * Wrapper for the Rackspace Cloud Queues API
- * 
+ *
  * @module  RacQ
  * @author Guy Vider
  * @copyright 2014 (c) Traveling Tech Guy LLC
@@ -10,8 +10,8 @@
  */
 
 /**
- * @constructor 
- * 
+ * @constructor
+ *
  * @param {Object} [options] null, or an object containing the following properties:
  * 		@param {String} options.userName - Rackspace user name (specify here, or when calling {@link authenticate})
  * 		@param {String} options.apiKey	- Rackspace API key (specify here, or when calling {@link authenticate})
@@ -29,7 +29,7 @@ var RacQ = function(options) {
 		debug = dbg('racq'),
 		statistics = dbg('racq:statistics'),
 		errors = require('./errors');
-		
+
 	//private variables
 	var _userName,
 		_apiKey,
@@ -60,7 +60,7 @@ var RacQ = function(options) {
 			}
 			else {
 				debug('file %s does not exist', _persistedTokenPath);
-			}	
+			}
 		}
 		else {
 			debug('no path provided');
@@ -95,7 +95,7 @@ var RacQ = function(options) {
 			return callback(error, response, body);
 		});
 	};
-	
+
 	//return error object for function, based on response status code
 	var returnError = function(functionName, statusCode) {
 		statusCode = statusCode.toString();
@@ -190,7 +190,7 @@ var RacQ = function(options) {
 			urls = require('./urls');
 
 		_defaultRegion =  (options && options.region) ? options.region : 'dfw';
-		_authUrl = urls.authUrl;	
+		_authUrl = urls.authUrl;
 		_queueUrl = urls.queueUrl.replace('REGION', _defaultRegion);
 		_clientId = (options && options.clientId) ? options.clientId : guid.raw();
 		_statistics = {
@@ -231,11 +231,11 @@ var RacQ = function(options) {
 
 	/**
 	 * Authenticate API calls
-	 * 
+	 *
 	 * Authenticates credentials against Rackspace auth endpoint, receiveing the auth token used in the rest of the calls.
-	 * If a path has been specified in constructor, token will be taken from local file, 
+	 * If a path has been specified in constructor, token will be taken from local file,
 	 * and received token will be persisted to local file.
-	 * 
+	 *
 	 * @param {String} [userName] - Rackspace user name (if not provided to constructor)
 	 * @param {String} [apiKey] - Rackspace user name (if not provided to constructor)
 	 * @param {Function} callback - the function to call when authentication ends. Returns with null on success, or error object
@@ -251,18 +251,18 @@ var RacQ = function(options) {
 		if(_token && (new Date(_token.expires)) > Date.now()) {
 			return callback(null);
 		}
-		
+
 		var options = {
 				url: _authUrl,
 				json: {
 					auth: {
 						'RAX-KSKEY:apiKeyCredentials': {
-							'username': userName, 
+							'username': userName,
 							'apiKey': apiKey
 						}
 					}
 				}
-			};		
+			};
 		httpRequest('post', options, function(error, response, body) {
 			if (!error && (response.statusCode === 200 || response.statusCode === 203)) {
 				_token = body.access.token;
@@ -279,13 +279,13 @@ var RacQ = function(options) {
 			}
 		});
 	};
-	
+
 	///////////////////////
 	// Queue operations  //
 	///////////////////////
 	/**
 	 * List all queues in account, in alphabetical order
-	 * 
+	 *
 	 * @param {Object} [parameters] - query parameters. Can be null, or an object with one or more of the following:
 	 * 		@param {Integer} [parameters.limit] - limit number of queues returned (1-10, default: 10)
 	 * 		@param {Integer} [parameters.marker] - The marker to use to get the next batch of messages
@@ -358,7 +358,7 @@ var RacQ = function(options) {
 				debug('deleteQueue: ' + (error || 'statusCode: ' + response.statusCode));
 				return callback(error || returnError('deleteQueue', response.statusCode));
 			}
-		});	
+		});
 	};
 
 	/**
@@ -381,12 +381,16 @@ var RacQ = function(options) {
 					debug('queue %s does not exist', queueName);
 					return callback(null, false);
 				}
+                else if(response.statusCode === 401) {
+                    debug('queueExists: ' + (error || 'statusCode: ' + response.statusCode));
+                    return callback(returnError('queueExists', response.statusCode));
+                }
 			}
 			else {
 				debug('queueExists: ' + error);
 				return callback(error);
 			}
-		});	
+		});
 	};
 
 	/**
@@ -409,12 +413,12 @@ var RacQ = function(options) {
 				debug('getQueueStats: ' + (error || 'statusCode: ' + response.statusCode));
 				return callback(error || returnError('getQueueStats', response.statusCode), null);
 			}
-		});	
+		});
 	};
-	
+
 	/**
 	 * Set queue metatdata
-	 * 
+	 *
 	 * @param {String}   queueName
 	 * @param {Object}   metadata
 	 * @param {Function} callback - Returns null on success, or error object
@@ -433,12 +437,12 @@ var RacQ = function(options) {
 				debug('setQueueMetadata: ' + (error || 'statusCode: ' + response.statusCode));
 				return callback(error || returnError('setQueueMetadata', response.statusCode));
 			}
-		});	
+		});
 	};
 
 	/**
 	 * Get queue metadata
-	 * 
+	 *
 	 * @param  {String}   queueName
 	 * @param  {Function} callback - Returns with queue metadata, or error object
 	 */
@@ -457,7 +461,7 @@ var RacQ = function(options) {
 				debug('getQueueMetadata: ' + (error || 'statusCode: ' + response.statusCode));
 				return callback(error || returnError('getQueueMetadata', response.statusCode), null);
 			}
-		});	
+		});
 	};
 
 	//////////////////////////
@@ -465,7 +469,7 @@ var RacQ = function(options) {
 	//////////////////////////
 	/**
 	 * Put message/s in queue
-	 * 
+	 *
 	 * @param  {String}			queueName
 	 * @param  {Object|Array}	messages - Object, or Array of Objects, 1-10 messages in the following format:
 	 * 							@param {Integer} messages.ttl Time-To-Live for message in seconds (min. value 60)
@@ -497,7 +501,7 @@ var RacQ = function(options) {
 	/**
 	 * Get messages from queue
 	 * Can be invoked with 2, 3 or 4 parameters: queueName, [echo], [limit], callback
-	 *  
+	 *
 	 * @param {String} queueName
 	 * @param {Object} [parameters] - query parameters. Can be null, or an object with one or more of the following:
 	 * 		@param {Integer} [parameters.limit] - limit number of messages returned (1-10, default: 10)
@@ -534,7 +538,7 @@ var RacQ = function(options) {
 
 	/**
 	 * Get message/s by id/s
-	 * 
+	 *
 	 * @param  {String}   queueName
 	 * @param  {String}   messageIds - one or more message ids, seperated by comma
 	 * @param  {Function} callback - Returns array of message objects on success, or error object
@@ -557,7 +561,7 @@ var RacQ = function(options) {
 
 	/**
 	 * Delete message from queue
-	 * 
+	 *
 	 * @param  {String}   queueName
 	 * @param  {String}   messageIds - one or more message ids, separated by comma
 	 * @param {String} [claimId] - if provided, will provide the claim Id for a SINGLE message to be deleted
@@ -594,7 +598,7 @@ var RacQ = function(options) {
 	/**
 	 * Claim messages: a client can mark messages it's handling with a claim, delete them upon process end,
 	 * or releasing the claim if it takes too long to process
-	 * 
+	 *
 	 * @param  {String}   queueName
 	 * @param  {Object}   [parameters] - claim paramters:
 	 *					@param {Integer} [parameters.limit] maximum number of messages to claim. Can be 1-20, default 10
@@ -624,7 +628,7 @@ var RacQ = function(options) {
 			}
 			else if(response.statusCode === 204) {
 				debug('claimMessages: no messages claimed');
-				return callback(null, null);	
+				return callback(null, null);
 			}
 			else {
 				debug('claimMessages: ' + (error || 'statusCode: ' + response.statusCode));
@@ -635,7 +639,7 @@ var RacQ = function(options) {
 
 	/**
 	 * Check which massages are claimed by claim ids
-	 * 
+	 *
 	 * @param  {String}   queueName
 	 * @param  {String}   claimIds - one, or more claim ids to verify, separated by comma
 	 * @param  {Function} callback - Returns array of message objects on success, or error object
@@ -662,7 +666,7 @@ var RacQ = function(options) {
 
 	/**
 	 * Update the TTL and grace period of claimed messages
-	 * 
+	 *
 	 * @param  {String}   queueName
 	 * @param  {String}   claimIds - one, or more claim ids to verify, separated by comma
 	 * @param  {Object}   parameters
@@ -692,7 +696,7 @@ var RacQ = function(options) {
 
 	/**
 	 * Release claim on messages, allowing them to be claimed by a different client
-	 * 
+	 *
 	 * @param  {String}   queueName
 	 * @param  {String}   claimIds - one, or more claim ids to verify, separated by comma
 	 * @param  {Function} callback - Returns null on success, or error object
@@ -713,6 +717,14 @@ var RacQ = function(options) {
 			}
 		});
 	};
+
+    /**
+     * Resets the token to allow fetching new token even if the current one isn't expired yet
+     *
+     */
+    this.deleteToken = function() {
+        _token = null;
+    }
 };
 
 module.exports = RacQ;


### PR DESCRIPTION
Hello,
I needed a little a change in your work to make it possible to re-authenticate even if the stored token isn't expired yet. I added a deleteToken method to set the _token to nullI so the authenticate method will actually try to get a new token. The change needed because of:

```
//if we already have a valid token, return
if(_token && (new Date(_token.expires)) > Date.now()) {
    return callback(null);
}
```

I've found this necessary because the tokens might get invalidated before the expiration time.
I also added a check for 401 status code to the queueExists method.

Best regards,
Béla
