### PR TITLE
On createQueue() if a queue exists it is not an error (204).

### DIFF
--- a/lib/racq.js
+++ b/lib/racq.js
@@ -336,7 +336,7 @@ var RacQ = function(options) {
 				headers: getRequestHeaders(false)
 			};
 		httpRequest('put', options, function(error, response) {
-			if (!error && response.statusCode === 201) {
+			if (!error && (response.statusCode === 201 || response.statusCode === 204)) {
 				return callback(null);
 			}
 			else {


### PR DESCRIPTION
The relevant Rackspace API docs are [here](https://developer.rackspace.com/docs/cloud-queues/v1/developer-guide/#create-queue).
